### PR TITLE
Pretty results

### DIFF
--- a/src/routes/article/article.route.ts
+++ b/src/routes/article/article.route.ts
@@ -19,20 +19,16 @@ articleRouter.route('/:id')
 
 async function articlesGetMany(req: express.Request, res: express.Response) {
   try {
-    const error = validateParams(req.query);
-    if (error) {
-      return res.status(Status.BadRequest).send({ error });
-    }
     const {
-      search,
-      category,
       skip = DefaultQueryParams.Skip,
       limit = DefaultQueryParams.Limit,
     } = req.query;
-
+    const error = validateParams({ skip, limit });
+    if (error) {
+      return res.status(Status.BadRequest).send({ error });
+    }
     const { articles, total } = await DBService.paginateArticles({
-      search,
-      category,
+      ...req.query,
       skip: +skip,
       limit: +limit,
     });

--- a/src/routes/article/article.route.ts
+++ b/src/routes/article/article.route.ts
@@ -25,12 +25,14 @@ async function articlesGetMany(req: express.Request, res: express.Response) {
     }
     const {
       search,
+      category,
       skip = DefaultQueryParams.Skip,
       limit = DefaultQueryParams.Limit,
     } = req.query;
 
     const { articles, total } = await DBService.paginateArticles({
       search,
+      category,
       skip: +skip,
       limit: +limit,
     });

--- a/src/services/db.service.ts
+++ b/src/services/db.service.ts
@@ -62,7 +62,7 @@ export class DBService {
     return mtArticle.save();
   }
 
-  public static async paginateArticles({ search = '', skip = 0, limit = 200, category }) {
+  public static async paginateArticles({ search = '', skip = 0, limit = 200, category = '' }) {
     if (limit > 1000) {
       return Promise.reject(new Error('Using a limit higher than 1k is not allowed.'));
     }

--- a/src/services/db.service.ts
+++ b/src/services/db.service.ts
@@ -1,3 +1,4 @@
+import { ArticleStatus } from './../models/article/article.constants';
 import { Error } from 'mongoose';
 import splitargs from 'splitargs';
 import { ICategoryLean } from './../models/category/category.interface';
@@ -74,6 +75,12 @@ export class DBService {
     if (params.category) {
       const categories = await this.getSubcategories(params.category);
       query.category_id = { $in: categories };
+    }
+    if (params.pretty) {
+      // getting "pretty" articles
+      // => filtering for the ones that have images & are active
+      query.images = { $ne: [] };
+      query.status = ArticleStatus.Active;
     }
     try {
       const articles = await Article.find(query, null, { skip, limit });

--- a/src/services/db.service.ts
+++ b/src/services/db.service.ts
@@ -62,22 +62,22 @@ export class DBService {
     return mtArticle.save();
   }
 
-  public static async paginateArticles({ search = '', skip = 0, limit = 200, category = '' }) {
+  public static async paginateArticles({ skip = 0, limit = 200, ...params }) {
     if (limit > 1000) {
       return Promise.reject(new Error('Using a limit higher than 1k is not allowed.'));
     }
     // TODO: this should be in some utils or another function for query building
     const query: any = {};
-    const categories = await this.getSubcategories(category);
-    if (search) {
-      query.$text = { $search: this.parseSearchQuery(search) };
+    if (params.search) {
+      query.$text = { $search: this.parseSearchQuery(params.search) };
     }
-    if (categories.length) {
+    if (params.category) {
+      const categories = await this.getSubcategories(params.category);
       query.category_id = { $in: categories };
     }
     try {
       const articles = await Article.find(query, null, { skip, limit });
-      const total = search
+      const total = params.search
         ? await Article.find(query).count()
         : await Article.estimatedDocumentCount();
       return { articles, total };

--- a/test/db.service.spec.ts
+++ b/test/db.service.spec.ts
@@ -3,9 +3,15 @@ import mockdate from 'mockdate';
 import { expect } from 'chai';
 import { format, addDays } from 'date-fns';
 import { Article, Seller } from '../src/models';
-import { MLATEST_FIRST, MLATEST_SECOND, MLATEST_THIRD, MLATEST_ARTICLES_SEARCH_RESULT } from './mocks/articles.mock';
 import { SELLER_FIRST, SELLER_SECOND } from './mocks/sellers.mock';
 import { DBService } from '../src/services/db.service';
+import {
+  MLATEST_FIRST,
+  MLATEST_SECOND,
+  MLATEST_THIRD,
+  MLATEST_ARTICLES_SEARCH_RESULT,
+  MT_NO_IMAGES_AND_PAUSED_SEARCH_RESULT,
+} from './mocks/articles.mock';
 
 const leanPrice = 123;
 const baseArticles = [MLATEST_FIRST, MLATEST_SECOND, MLATEST_THIRD];
@@ -13,6 +19,7 @@ const updatedArticles = baseArticles.map(article => Object.assign({}, article, {
 
 describe('DBService', () => {
   before(() => mongoose.connection.dropCollection('articles'));
+
   it('should insertMany articles', async () => {
     await DBService.createArticles(MLATEST_ARTICLES_SEARCH_RESULT, 'category_id');
     const articles = await Article.find();
@@ -21,6 +28,7 @@ describe('DBService', () => {
     expect(articles[0].seller_id).to.equal(123);
     expect(articles[2].seller_id).to.equal(999);
   });
+
   it('should update lean and newly created articles', async () => {
     let articles = await Article.find();
     await DBService.updateArticles(articles, baseArticles);
@@ -30,6 +38,7 @@ describe('DBService', () => {
       expect(article.price).to.exist;
     }
   });
+
   it('should update articles with a different price', async () => {
     let articles = await Article.find();
     await DBService.updateArticles(articles, updatedArticles);
@@ -43,6 +52,7 @@ describe('DBService', () => {
       expect(article.price).to.be.eq(leanPrice);
     }
   });
+
   it('should update article with a different status', async () => {
     const pausedStatusObj = { status: 'paused' };
     let articles = await Article.find();
@@ -52,6 +62,7 @@ describe('DBService', () => {
     const updatedArticle = articles.find(article => article.id === articleWithDifferentStatus.id);
     expect(updatedArticle).to.exist.and.to.include(pausedStatusObj);
   });
+
   it('should not update articles when only the date changes', async () => {
     mockdate.set(addDays(new Date(), 1)); // mocking today as tomorrow
     let articles = await Article.find();
@@ -74,7 +85,7 @@ describe('DBService', () => {
       .and.to.have.members(['"somewhere"', '"text"', '"with quotes"', '"some"']) // with quotes
       .and.not.to.have.members(['somewhere', 'text', 'with quotes', 'some']); // without quotes
   });
-  
+
   it('should add sellers correctly', async () => {
     await DBService.addSellers([SELLER_FIRST, SELLER_FIRST, SELLER_FIRST, SELLER_SECOND]).catch(() => {
       // silent fail
@@ -84,4 +95,17 @@ describe('DBService', () => {
     expect(sellers.slice().shift().id).to.equal(SELLER_FIRST.id);
     expect(sellers.slice().pop().id).to.equal(SELLER_SECOND.id);
   });
+
+  it('should not return non-active articles if pretty articles are requested', async () => {
+    await DBService.createArticles([ MT_NO_IMAGES_AND_PAUSED_SEARCH_RESULT ], 'category_id');
+    let target;
+    let page;
+    page = await DBService.paginateArticles({});
+    target = page.articles.find(article => article.id === MT_NO_IMAGES_AND_PAUSED_SEARCH_RESULT.id);
+    expect(target).to.exist;
+    page = await DBService.paginateArticles({ pretty: true });
+    target = page.articles.find(article => article.id === MT_NO_IMAGES_AND_PAUSED_SEARCH_RESULT.id);
+    expect(target).to.not.exist;
+  });
+
 });

--- a/test/mocks/articles.mock.ts
+++ b/test/mocks/articles.mock.ts
@@ -89,6 +89,20 @@ export const MT_EXPENSIVE: IArticle = {
   history: [{ original_price: 300, price: 360, fluctuation: 0 }]
 };
 
+export const MT_NO_IMAGES_AND_PAUSED_SEARCH_RESULT = {
+  id: 'MT_NO_IMAGES_AND_PAUSED',
+  title: 'Expensive Title',
+  original_price: null,
+  currency_id: 'ARS',
+  price: 360,
+  thumbnail: 'www.thumbnail.com/MT_NO_IMAGES_AND_PAUSED',
+  status: 'paused',
+  seller: {
+    id: 999,
+  },
+  history: [{ original_price: 300, price: 360, fluctuation: 0 }]
+};
+
 export const MLATEST_ARTICLES_SEARCH_RESULT: ISearchMLArticle[] = [
   {
     ...MLATEST_FIRST,


### PR DESCRIPTION
- refactor(articles get many): avoiding future code writing overhead
  _instead of defining all query params now we're using rest param_

- feat(articles get many): pretty results
  _when pretty query param is provided we will only return articles with images and in active status_